### PR TITLE
Refactor record endpoints

### DIFF
--- a/app/controllers/api/v1/transactions/find_controller.rb
+++ b/app/controllers/api/v1/transactions/find_controller.rb
@@ -10,6 +10,6 @@ class Api::V1::Transactions::FindController < ApplicationController
   private
 
   def search_params
-    params.permit(:id, :credit_card_number, :result, :created_at, :updated_at)
+    params.permit(:id, :credit_card_number, :result, :invoice_id, :created_at, :updated_at)
   end
 end

--- a/db/migrate/20170628024720_change_transactions.rb
+++ b/db/migrate/20170628024720_change_transactions.rb
@@ -1,0 +1,6 @@
+class ChangeTransactions < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :transactions, :credit_card_number, :integer
+    add_column    :transactions, :credit_card_number, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170626233703) do
+ActiveRecord::Schema.define(version: 20170628024720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,11 +60,11 @@ ActiveRecord::Schema.define(version: 20170626233703) do
   end
 
   create_table "transactions", force: :cascade do |t|
-    t.bigint "credit_card_number"
     t.text "result"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "invoice_id"
+    t.text "credit_card_number"
     t.index ["invoice_id"], name: "index_transactions_on_invoice_id"
   end
 

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -1,42 +1,61 @@
 require 'csv'
 
-namespace :import_everything do
-  task :create_everything => :environment do
+namespace :import do
+  task :all => [:regenerate, :import_customers, :import_merchants, :import_items, :import_invoices, :import_invoice_items, :import_transactions]
+
+  task :regenerate do
+    Rails.env = "development"
+    Rake::Task["db:reset"].invoke
+    Rails.env = "test"
+    Rake::Task["db:reset"].invoke
+  end
+
+  task :import_customers => [:environment] do
     file = File.read('./db/data/customers.csv')
     csv = CSV.parse(file, :headers => true)
     csv.each do |row|
       customer = Customer.create!(row.to_hash)
       puts "created customer #{customer.id}"
     end
+  end
 
+  task :import_merchants => [:environment] do
     file = File.read('./db/data/merchants.csv')
     csv = CSV.parse(file, :headers => true)
     csv.each do |row|
       merchant = Merchant.create!(row.to_hash)
       puts "created merchant #{merchant.id}"
     end
+  end
 
+  task :import_items => [:environment] do
     file = File.read('./db/data/items.csv')
     csv = CSV.parse(file, :headers => true)
     csv.each do |row|
       item = Item.create!(row.to_hash)
       puts "created item #{item.id}"
     end
+  end
 
+  task :import_invoices => [:environment] do
     file = File.read('./db/data/invoices.csv')
     csv = CSV.parse(file, :headers => true)
     csv.each do |row|
       invoice = Invoice.create!(row.to_hash)
       puts "created invoice #{invoice.id}"
     end
+  end
 
+  task :import_invoice_items => [:environment] do
     file = File.read('./db/data/invoice_items.csv')
     csv = CSV.parse(file, :headers => true)
     csv.each do |row|
       invoice_item = InvoiceItem.create!(row.to_hash)
       puts "created invoice_item #{invoice_item.id}"
     end
+  end
 
+  task :import_transactions => [:environment] do
     file = File.read('./db/data/transactions.csv')
     csv = CSV.parse(file, :headers => true, :header_converters => :symbol)
     csv.each do |row|

--- a/spec/requests/api/v1/transaction_records_spec.rb
+++ b/spec/requests/api/v1/transaction_records_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'tranactions_records_api', type: :request do
         create(:transaction)
       end
 
-      get '/api/v1/transactions/find_all', params: {credit_card_number: 1234123412341234}
+      get '/api/v1/transactions/find_all', params: {credit_card_number: "1234123412341234"}
       result = JSON.parse(response.body)
       
       expect(response).to have_http_status(200)

--- a/spec/requests/api/v1/transaction_records_spec.rb
+++ b/spec/requests/api/v1/transaction_records_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'tranactions_records_api', type: :request do
       result = JSON.parse(response.body)
 
       expect(response).to have_http_status(200)
-      expect(result["credit_card_number"]).to be_a(Integer)
+      expect(result["credit_card_number"]).to be_a(String)
     end
   end
 


### PR DESCRIPTION
@MasonHolland Hey Mason. I made a change to the database. You'll need to migrate, which changes the credit card number in transactions to a string. I ran the spec harness which told me I was wrong. 

Also, I changed the rake file. Now you can run with `rake import:all` instead which also drops your database in one command. If you want to seed just one thing, it is `rake import:import_customers`.

At the moment. We are passing all tests for the record endpoints for transactions, merchants, and customers except for one test in each which can only be corrected by using the serializer.